### PR TITLE
fix: drop PHP versions 7.1 and 7.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,18 +21,18 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - php: '7.2'
+                    - php: '7.3'
                       symfony: '3.4.*'
                     - php: '7.4'
                       symfony: '3.4.*'
-                    - php: '7.2'
+                    - php: '7.3'
                       symfony: '4.4.*'
                     - php: '7.4'
                       symfony: '4.4.*'
-                    - php: '7.2'
-                      symfony: '5.1.*'
+                    - php: '7.3'
+                      symfony: '5.2.*'
                     - php: '7.4'
-                      symfony: '5.1.*'
+                      symfony: '5.2.*'
         steps:
             - name: checkout
               uses: actions/checkout@v2
@@ -72,7 +72,7 @@ jobs:
                 symfony:
                     - '3.4.*'
                     - '4.4.*'
-                    - '5.1.*'
+                    - '5.2.*'
         steps:
             - name: checkout
               uses: actions/checkout@v2

--- a/Tests/Functional/TestProjectFiles/bundleLoaded/src/Command/TestCommand.php
+++ b/Tests/Functional/TestProjectFiles/bundleLoaded/src/Command/TestCommand.php
@@ -24,7 +24,7 @@ class TestCommand extends Command
         $this->tracingId = $tracingId;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $request = new Request('GET', '/');
 

--- a/Tests/Functional/TestProjectFiles/bundleLoaded/src/Controller/TestController.php
+++ b/Tests/Functional/TestProjectFiles/bundleLoaded/src/Controller/TestController.php
@@ -18,7 +18,7 @@ class TestController extends AbstractController
         $this->client = $client;
     }
 
-    public function index(HttpClient $client)
+    public function index(HttpClient $client): JsonResponse
     {
         $request = new Request('GET', 'https://github.com/auxmoney/OpentracingBundle-HttplugBundle');
 

--- a/Tests/Functional/TestProjectFiles/bundleNotLoaded/src/Command/TestCommand.php
+++ b/Tests/Functional/TestProjectFiles/bundleNotLoaded/src/Command/TestCommand.php
@@ -19,12 +19,12 @@ class TestCommand extends Command
     public function __construct(HttpClient $client, TracingId $tracingId)
     {
         parent::__construct('test:httplug');
-        $this->setDescription('some fancy command description');    
+        $this->setDescription('some fancy command description');
         $this->client = $client;
         $this->tracingId = $tracingId;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $request = new Request('GET', '/');
 

--- a/Tests/Functional/TestProjectFiles/bundleNotLoaded/src/Controller/TestController.php
+++ b/Tests/Functional/TestProjectFiles/bundleNotLoaded/src/Controller/TestController.php
@@ -18,7 +18,7 @@ class TestController extends AbstractController
         $this->client = $client;
     }
 
-    public function index(HttpClient $client)
+    public function index(HttpClient $client): JsonResponse
     {
         $request = new Request('GET', 'https://github.com/auxmoney/OpentracingBundle-HttplugBundle');
 

--- a/Tests/Unit/DependencyInjection/HttplugPluginClientFactoryCompilerPassTest.php
+++ b/Tests/Unit/DependencyInjection/HttplugPluginClientFactoryCompilerPassTest.php
@@ -4,31 +4,29 @@ declare(strict_types=1);
 
 namespace Auxmoney\OpentracingHttplugBundle\Tests\Unit\DependencyInjection;
 
-use Prophecy\Argument;
-use PHPUnit\Framework\TestCase;
+use Auxmoney\OpentracingHttplugBundle\DependencyInjection\HttplugPluginClientFactoryCompilerPass;
+use Auxmoney\OpentracingHttplugBundle\Factory\DecoratedPluginClientFactory;
 use Http\Client\Common\PluginClient;
 use Http\Client\Common\PluginClientFactory;
-use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\Definition;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Auxmoney\OpentracingHttplugBundle\Factory\DecoratedPluginClientFactory;
-use Auxmoney\OpentracingHttplugBundle\DependencyInjection\HttplugPluginClientFactoryCompilerPass;
-use Prophecy\Doubler\Generator\Node\ArgumentNode;
-use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 class HttplugPluginClientFactoryCompilerPassTest extends TestCase
 {
     /** @var HttplugPluginClientFactoryCompilerPass */
     private $subject;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->subject = new HttplugPluginClientFactoryCompilerPass();
     }
-    
-    public function dataOfNonDesiredFactories()
+
+    public function dataOfNonDesiredFactories(): array
     {
         $factoryReferenceOkButWrongServiceId = $this->prophesize(Reference::class);
         $factoryReferenceOkButWrongServiceId->__toString()->willReturn('wrongServiceId'); // here!
@@ -50,7 +48,7 @@ class HttplugPluginClientFactoryCompilerPassTest extends TestCase
             ]
         ];
     }
-    
+
     /**
      * @param string|array|null $factory
      * @dataProvider dataOfNonDesiredFactories
@@ -62,7 +60,7 @@ class HttplugPluginClientFactoryCompilerPassTest extends TestCase
 
         $clientDefinition->getFactory()->willReturn($factory);
         $clientDefinition->setFactory(Argument::any())->shouldNotBeCalled();
-        
+
         $container = new ContainerBuilder();
         $container->addDefinitions([
             'client' => $clientDefinition->reveal()
@@ -85,7 +83,7 @@ class HttplugPluginClientFactoryCompilerPassTest extends TestCase
         ]);
 
         $clientDefinition->setFactory(Argument::any())->shouldNotBeCalled();
-        
+
         $container = new ContainerBuilder();
         $container->addDefinitions([
             'client' => $clientDefinition->reveal()
@@ -98,10 +96,10 @@ class HttplugPluginClientFactoryCompilerPassTest extends TestCase
     {
         $clientDefinition = $this->prophesize(Definition::class);
         $clientDefinition->getClass()->willReturn(PluginClient::class);
-        
+
         $clientFactory = $this->prophesize(Reference::class);
         $clientFactory->__toString()->willReturn(PluginClientFactory::class);
-        
+
         $clientDefinition->getFactory()->willReturn([
             $clientFactory->reveal(),
             'factoryMethodOfPluginClientFactory'
@@ -111,7 +109,7 @@ class HttplugPluginClientFactoryCompilerPassTest extends TestCase
             new Reference(DecoratedPluginClientFactory::class),
             'createClient'
         ]))->shouldBeCalled();
-        
+
         $container = new ContainerBuilder();
         $container->addDefinitions([
             'client' => $clientDefinition->reveal()

--- a/Tests/Unit/Plugin/OpentracingPluginTest.php
+++ b/Tests/Unit/Plugin/OpentracingPluginTest.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 namespace Auxmoney\OpentracingHttplugBundle\Tests\Unit\Plugin;
 
+use Auxmoney\OpentracingBundle\Internal\Decorator\RequestSpanning;
+use Auxmoney\OpentracingBundle\Service\Tracing;
+use Auxmoney\OpentracingHttplugBundle\Plugin\OpentracingPlugin;
+use Http\Client\Exception\HttpException;
+use Http\Client\Exception\TransferException;
+use Http\Client\Promise\HttpFulfilledPromise;
+use Http\Client\Promise\HttpRejectedPromise;
 use Nyholm\Psr7\Request;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Http\Client\Exception\HttpException;
-use Http\Client\Exception\TransferException;
-use Http\Client\Promise\HttpRejectedPromise;
-use Http\Client\Promise\HttpFulfilledPromise;
-use Auxmoney\OpentracingBundle\Service\Tracing;
-use Auxmoney\OpentracingHttplugBundle\Plugin\OpentracingPlugin;
-use Auxmoney\OpentracingBundle\Internal\Decorator\RequestSpanning;
 
 class OpentracingPluginTest extends TestCase
 {
@@ -26,7 +26,7 @@ class OpentracingPluginTest extends TestCase
     /** @var Tracing|ObjectProphecy */
     private $tracing;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->requestSpanning = $this->prophesize(RequestSpanning::class);
@@ -50,7 +50,7 @@ class OpentracingPluginTest extends TestCase
         $subject = new OpentracingPlugin($this->requestSpanning->reveal(), $this->tracing->reveal());
 
         $next = function (RequestInterface $request) use ($injectedRequest) {
-            $this->assertSame($request, $injectedRequest);
+            self::assertSame($request, $injectedRequest);
             return new HttpFulfilledPromise(new Response(201, [], 'some body'));
         };
 
@@ -88,7 +88,7 @@ class OpentracingPluginTest extends TestCase
         $subject = new OpentracingPlugin($this->requestSpanning->reveal(), $this->tracing->reveal());
 
         $next = function (RequestInterface $request) use ($injectedRequest, $exceptionToBeThrown) {
-            $this->assertSame($request, $injectedRequest);
+            self::assertSame($request, $injectedRequest);
             return new HttpRejectedPromise($exceptionToBeThrown);
         };
 
@@ -125,7 +125,7 @@ class OpentracingPluginTest extends TestCase
         $subject = new OpentracingPlugin($this->requestSpanning->reveal(), $this->tracing->reveal());
 
         $next = function (RequestInterface $request) use ($injectedRequest, $exceptionToBeThrown) {
-            $this->assertSame($request, $injectedRequest);
+            self::assertSame($request, $injectedRequest);
             return new HttpRejectedPromise($exceptionToBeThrown);
         };
 

--- a/composer.json
+++ b/composer.json
@@ -16,23 +16,23 @@
   "type": "symfony-bundle",
   "license": "MIT",
   "require": {
-    "php": "^7.2.33",
+    "php": "^7.3.27",
     "opentracing/opentracing": "1.0.0-beta5@beta",
-    "auxmoney/opentracing-bundle-core": "^v0.7.2",
-    "php-http/httplug-bundle": "^1.19"
+    "auxmoney/opentracing-bundle-core": "^v0.8",
+    "php-http/httplug-bundle": "^1.20"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",
     "phpunit/phpunit": "^7.5",
     "phpstan/phpstan": "^0.12",
-    "squizlabs/php_codesniffer": "^3.5",
-    "phpmd/phpmd": "^2.7",
-    "php-coveralls/php-coveralls": "^2.2",
+    "squizlabs/php_codesniffer": "^3.6",
+    "phpmd/phpmd": "^2.9",
+    "php-coveralls/php-coveralls": "^2.4",
     "symfony/filesystem": "*",
     "symfony/process": "*",
     "symfony/yaml": "*",
-    "mtdowling/jmespath.php": "^2.5",
-    "nyholm/psr7": "^1.3",
+    "mtdowling/jmespath.php": "^2.6",
+    "nyholm/psr7": "^1.4",
     "php-http/curl-client": "^2.2"
   },
   "autoload": {


### PR DESCRIPTION
relates to https://github.com/auxmoney/OpentracingBundle-core/issues/55